### PR TITLE
fix: correct variable name inline, and in example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,10 +16,10 @@ For example if the git server lives at <code class="language-yaml">https://gitea
 put `gitea-gitea.apps.hivec.sandbox1243.opentlc.com`in the box to generate the correct address for the exercises.
 
 ## 🦆 Conventions
-When running through the exercise, we're tried to call out where things need replacing. The key ones are anything inside an `<>` should be replaced. For example, if your team is called `biscuits` then in the instructions if you see `\<USER_NAME\>` this should be replaced with `biscuits` like so:
+When running through the exercise, we're tried to call out where things need replacing. The key ones are anything inside an `<>` should be replaced. For example, if your team is called `biscuits` then in the instructions if you see `<USER_NAME>` this should be replaced with `biscuits` like so:
     <div class="highlight" style="background: #f7f7f7">
     <pre><code class="language-bash">
-    name: <\USER_NAME\>
+    name: &lt;USER_NAME&gt;
     # ^ this becomes
     name: biscuits
     </code></pre></div>


### PR DESCRIPTION
We're Team 2 "MLP" :)

@RHRolun @ckavili @rcarrata @lpanza @trg-pauline 

Expectation reference example in pages without header bar populated:

<img width="1554" alt="Screenshot 2025-05-03 at 13 05 56" src="https://github.com/user-attachments/assets/c0695592-74d2-4346-a2bd-4e87c61bd554" />

## BEFORE (today):

<img width="1533" alt="Screenshot 2025-05-03 at 13 06 15" src="https://github.com/user-attachments/assets/74c5aefc-aea3-43c0-9e26-a4aa4bca8144" />

## AFTER (this PR):

<img width="1525" alt="Screenshot 2025-05-03 at 13 09 12" src="https://github.com/user-attachments/assets/9238accd-1a77-474b-9749-ff53dbefe5c6" />

