### PR TITLE
Cleaner oc login snippets

### DIFF
--- a/docs/3-from-studio-to-stage/1-gitops.md
+++ b/docs/3-from-studio-to-stage/1-gitops.md
@@ -35,8 +35,7 @@ Let’s create a new workbench next to the existing Jupyter Notebook workbench i
   Log in to OpenShift using your credentials (remember to replace <PASSWORD> with your actual password).
 
   ```bash
-    export CLUSTER_DOMAIN=<CLUSTER_DOMAIN>
-    oc login --server=https://api.${CLUSTER_DOMAIN##apps.}:6443 -u <USER_NAME> -p <PASSWORD>
+    oc login --server=https://api.<TRIMMED_CLUSTER_DOMAIN>:6443 -u <USER_NAME> -p <PASSWORD>
   ```
 
   Then check if Argo CD pods are alive:

--- a/docs/8-the-supporting-acts/4-code-analysis.md
+++ b/docs/8-the-supporting-acts/4-code-analysis.md
@@ -50,8 +50,7 @@
     _And in case you logged out from the cluster, use below commands to login again._
 
     ```bash
-    export CLUSTER_DOMAIN=<CLUSTER_DOMAIN>
-    oc login --server=https://api.${CLUSTER_DOMAIN##apps.}:6443 -u <USER_NAME> -p <PASSWORD>
+    oc login --server=https://api.<TRIMMED_CLUSTER_DOMAIN>:6443 -u <USER_NAME> -p <PASSWORD>
     ```
 
 5. Before extending the pipeline with SonarQube, we can run the code quality checks from our IDE. Fist, let's install the `pysonar` library.

--- a/docs/8-the-supporting-acts/5-sealed-secrets.md
+++ b/docs/8-the-supporting-acts/5-sealed-secrets.md
@@ -30,8 +30,7 @@ Sealed Secrets allows us to _seal_ Kubernetes secrets by using a utility called 
     </p>
 
     ```bash
-    export CLUSTER_DOMAIN=<CLUSTER_DOMAIN>
-    oc login --server=https://api.${CLUSTER_DOMAIN##apps.}:6443 -u <USER_NAME> -p thisisthepassword
+    oc login --server=https://api.<TRIMMED_CLUSTER_DOMAIN>:6443 -u <USER_NAME> -p thisisthepassword
 
     ```
 

--- a/docs/8-the-supporting-acts/7-image-security.md
+++ b/docs/8-the-supporting-acts/7-image-security.md
@@ -27,8 +27,7 @@ StackRox (Advanced Cluster Security, or ACS) is deployed at the cluster level an
     _And in case you logged out from the cluster, use below commands to login again._
 
     ```bash
-    export CLUSTER_DOMAIN=<CLUSTER_DOMAIN>
-    oc login --server=https://api.${CLUSTER_DOMAIN##apps.}:6443 -u <USER_NAME> -p <PASSWORD>
+    oc login --server=https://api.<TRIMMED_CLUSTER_DOMAIN>:6443 -u <USER_NAME> -p <PASSWORD>
     ```
 
     Export the StackRox endpoint:

--- a/docs/8-the-supporting-acts/8-signing.md
+++ b/docs/8-the-supporting-acts/8-signing.md
@@ -32,8 +32,7 @@
     </p>
 
     ```bash
-    export CLUSTER_DOMAIN=<CLUSTER_DOMAIN>
-    oc login --server=https://api.${CLUSTER_DOMAIN##apps.}:6443 -u <USER_NAME> -p <PASSWORD>
+    oc login --server=https://api.<TRIMMED_CLUSTER_DOMAIN>:6443 -u <USER_NAME> -p <PASSWORD>
     ```
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,7 @@
     // Populate dropdown links with dynamic values
     function populateDropdownLinks() {
       const clusterDomain = localStorage.getItem('CLUSTER_DOMAIN') ? localStorage.getItem('CLUSTER_DOMAIN') : '<CLUSTER_DOMAIN>';
+      const trimmedClusterDomain = clusterDomain.replace(/^apps\./, '');
       const gitServer = localStorage.getItem('GIT_SERVER') ? localStorage.getItem('GIT_SERVER') : '<GIT_SERVER>';
       const username = localStorage.getItem('USER_NAME') ? localStorage.getItem('USER_NAME') : '<USER_NAME>';
       
@@ -181,10 +182,12 @@
             const userName = localStorage.getItem('USER_NAME') ? localStorage.getItem('USER_NAME') : '<USER_NAME>';
             const passWord = localStorage.getItem('PASSWORD') ? localStorage.getItem('PASSWORD') : '<PASSWORD>';
             const clusterDomain = localStorage.getItem('CLUSTER_DOMAIN') ? localStorage.getItem('CLUSTER_DOMAIN') : '<CLUSTER_DOMAIN>';
+            const trimmedClusterDomain = clusterDomain.replace(/^apps\./, '');
             const gitServer = localStorage.getItem('GIT_SERVER') ? localStorage.getItem('GIT_SERVER') : '<GIT_SERVER>';
             return content.replaceAll('<USER_NAME>', userName)
                     .replaceAll('<PASSWORD>', passWord)
                     .replaceAll('<CLUSTER_DOMAIN>', clusterDomain)
+                    .replaceAll('<TRIMMED_CLUSTER_DOMAIN>', trimmedClusterDomain)
                     .replaceAll('<GIT_SERVER>', gitServer);
           });
 


### PR DESCRIPTION
This is to remove env variable use from `oc login` bash snippets (at first glance, they might look as not correctly parsed values).