### PR TITLE
Start scan 🩻 from the top path 🔝

### DIFF
--- a/docs/8-the-supporting-acts/4-code-analysis.md
+++ b/docs/8-the-supporting-acts/4-code-analysis.md
@@ -62,6 +62,7 @@
     and trigger a scan:
 
     ```bash
+    cd /opt/app-root/src
     pysonar-scanner -Dsonar.host.url=http://sonarqube.<USER_NAME>-toolings.svc.cluster.local:9000 -Dsonar.projectKey=jukebox -Dsonar.login=admin -Dsonar.password=<PASSWORD>
     ```
 


### PR DESCRIPTION
This solves an issue where mlops-helmcharts are not picked up if started from the mlops-gitops directory.