### PR TITLE
Add a git pull before commit to eliminate git merge conflict.

### DIFF
--- a/docs/5-the-data-tracks/2-update-ct-pipeline.md
+++ b/docs/5-the-data-tracks/2-update-ct-pipeline.md
@@ -83,6 +83,7 @@ And we have a bit of groundwork to cover first to set everything up properly.
 
     ```bash
     cd /opt/app-root/src/jukebox/
+    git pull
     git add 3-prod_datascience/prod_train_save_pipeline.py
     git commit -m "🍇 fetch data via DVC 🍇"
     git push


### PR DESCRIPTION
In Step 3 "From studio to stage" part "continuous training pipeline" the students are told to edit README.md file directly through Gitea web interface and the checkout in the workbench is now behind the remote.

When the students try to push their local changes they get a git merge conflict error message.